### PR TITLE
    Add support for specifying a single socket file on the command line.

### DIFF
--- a/haproxytool/acl.py
+++ b/haproxytool/acl.py
@@ -114,7 +114,7 @@ def main():
     arguments = docopt(__doc__)
     if (arguments['--socket']):
         try:
-            hap = haproxy.HAProxy(socket_file=arguments['--socket-file'])
+            hap = haproxy.HAProxy(socket_file=arguments['--socket'])
         except (SocketApplicationError,
                 SocketConnectionError,
                 SocketPermissionError) as error:

--- a/haproxytool/acl.py
+++ b/haproxytool/acl.py
@@ -8,14 +8,15 @@
 """Manage ACLs
 
 Usage:
-    haproxytool acl [-D DIR | -h] -l
-    haproxytool acl [-D DIR | -h] (-c | -s) ACLID
-    haproxytool acl [-D DIR | -h] (-A | -g ) ACLID VALUE
-    haproxytool acl [-D DIR | -h] -d ACLID KEY
+    haproxytool acl [(-D DIR | -F SOCK) | -h] -l
+    haproxytool acl [(-D DIR | -F SOCK) | -h] (-c | -s) ACLID
+    haproxytool acl [(-D DIR | -F SOCK) | -h] (-A | -g ) ACLID VALUE
+    haproxytool acl [(-D DIR | -F SOCK) | -h] -d ACLID KEY
 
 
 Arguments:
     DIR     Directory path
+    SOCK    Socket file
     ACLID   ID of the acl or file returned by show acl
     VALUE   Value to set
     KEY     Key ID of ACL value/pattern
@@ -29,6 +30,7 @@ Options:
     -l, --list                list all acl ids
     -d, --delete              delete all the acl entries from the acl <ACLID>
                               corresponding to the key <KEY>
+    -F SOCK, --socket=SOCK    use specific socket file
     -D DIR, --socket-dir=DIR  directory with HAProxy socket files
                               [default: /var/lib/haproxy]
 
@@ -110,16 +112,28 @@ class AclCommand(object):
 
 def main():
     arguments = docopt(__doc__)
-    try:
-        hap = haproxy.HAProxy(socket_dir=arguments['--socket-dir'])
-    except (SocketApplicationError,
-            SocketConnectionError,
-            SocketPermissionError) as error:
-        print(error, error.socket_file)
-        sys.exit(1)
-    except ValueError as error:
-        print(error)
-        sys.exit(1)
+    if (arguments['--socket']):
+        try:
+            hap = haproxy.HAProxy(socket_file=arguments['--socket-file'])
+        except (SocketApplicationError,
+                SocketConnectionError,
+                SocketPermissionError) as error:
+            print(error, error.socket_file)
+            sys.exit(1)
+        except ValueError as error:
+            print(error)
+            sys.exit(1)
+    else:
+        try:
+            hap = haproxy.HAProxy(socket_dir=arguments['--socket-dir'])
+        except (SocketApplicationError,
+                SocketConnectionError,
+                SocketPermissionError) as error:
+            print(error, error.socket_file)
+            sys.exit(1)
+        except ValueError as error:
+            print(error)
+            sys.exit(1)
 
     cmd = AclCommand(hap, arguments)
     method = get_arg_option(arguments)

--- a/haproxytool/backend.py
+++ b/haproxytool/backend.py
@@ -9,12 +9,13 @@
 """Manage backends
 
 Usage:
-    haproxytool backend [-D DIR ] (-S | -r | -p | -s | -i) [NAME...]
-    haproxytool backend [-D DIR ] (-l | -M)
-    haproxytool backend [-D DIR ] -m METRIC [NAME...]
+    haproxytool backend [(-D DIR | -F SOCK)] (-S | -r | -p | -s | -i) [NAME...]
+    haproxytool backend [(-D DIR | -F SOCK)] (-l | -M)
+    haproxytool backend [(-D DIR | -F SOCK)] -m METRIC [NAME...]
 
 Arguments:
     DIR     Directory path
+    SOCK    Socket file
     METRIC  Name of a metric, use '-M' to get metric names
 
 Options:
@@ -27,6 +28,7 @@ Options:
     -r, --requests            show requests
     -s, --status              show status
     -S, --servers             show servers
+    -F SOCK, --socket=SOCK    use specific socket file
     -D DIR, --socket-dir=DIR  directory with HAProxy socket files
                               [default: /var/lib/haproxy]
 
@@ -102,16 +104,28 @@ class BackendCommand(object):
 def main():
     arguments = docopt(__doc__)
 
-    try:
-        hap = haproxy.HAProxy(socket_dir=arguments['--socket-dir'])
-    except (SocketApplicationError,
-            SocketConnectionError,
-            SocketPermissionError) as error:
-        print(error)
-        sys.exit(1)
-    except ValueError as error:
-        print(error)
-        sys.exit(1)
+    if (arguments['--socket']):
+        try:
+            hap = haproxy.HAProxy(socket_file=arguments['--socket'])
+        except (SocketApplicationError,
+                SocketConnectionError,
+                SocketPermissionError) as error:
+            print(error)
+            sys.exit(1)
+        except ValueError as error:
+            print(error)
+            sys.exit(1)
+    else:
+        try:
+            hap = haproxy.HAProxy(socket_dir=arguments['--socket-dir'])
+        except (SocketApplicationError,
+                SocketConnectionError,
+                SocketPermissionError) as error:
+            print(error)
+            sys.exit(1)
+        except ValueError as error:
+            print(error)
+            sys.exit(1)
 
     cmd = BackendCommand(hap, arguments)
     method = get_arg_option(arguments)

--- a/haproxytool/dump.py
+++ b/haproxytool/dump.py
@@ -9,13 +9,14 @@
 """Dump a collection of information about frontends, backends and servers
 
 Usage:
-    haproxytool dump [-fbsh -D DIR ]
+    haproxytool dump [-fbsh (-D DIR | -F SOCK)]
 
 Options:
     -h, --help                show this screen
     -f, --frontends           show frontends
     -b, --backends            show backends
     -s, --servers             show servers
+    -F SOCK, --socket=SOCK    use specific socket file
     -D DIR, --socket-dir=DIR  directory with HAProxy socket files
                               [default: /var/lib/haproxy]
 
@@ -60,16 +61,28 @@ def main():
     arguments = docopt(__doc__)
     args_passed = False
 
-    try:
-        hap = haproxy.HAProxy(socket_dir=arguments['--socket-dir'])
-    except (SocketApplicationError,
-            SocketConnectionError,
-            SocketPermissionError) as error:
-        print(error)
-        sys.exit(1)
-    except ValueError as error:
-        print(error)
-        sys.exit(1)
+    if (arguments['--socket']):
+        try:
+            hap = haproxy.HAProxy(socket_file=arguments['--socket'])
+        except (SocketApplicationError,
+                SocketConnectionError,
+                SocketPermissionError) as error:
+            print(error)
+            sys.exit(1)
+        except ValueError as error:
+            print(error)
+            sys.exit(1)
+    else:
+        try:
+            hap = haproxy.HAProxy(socket_dir=arguments['--socket-dir'])
+        except (SocketApplicationError,
+                SocketConnectionError,
+                SocketPermissionError) as error:
+            print(error)
+            sys.exit(1)
+        except ValueError as error:
+            print(error)
+            sys.exit(1)
 
     if arguments['--frontends']:
         args_passed = True

--- a/haproxytool/frontend.py
+++ b/haproxytool/frontend.py
@@ -10,14 +10,15 @@
 """Manage frontends
 
 Usage:
-    haproxytool frontend [-D DIR ] (-c | -r | -s | -o | -e | -p | -i) [NAME...]
-    haproxytool frontend [-D DIR ] -w OPTION VALUE [NAME...]
-    haproxytool frontend [-D DIR -f ] (-d | -t) [NAME...]
-    haproxytool frontend [-D DIR ] (-l | -M)
-    haproxytool frontend [-D DIR ] -m METRIC [NAME...]
+    haproxytool frontend [(-D DIR | -F SOCK)] (-c | -r | -s | -o | -e | -p | -i) [NAME...]
+    haproxytool frontend [(-D DIR | -F SOCK)] -w OPTION VALUE [NAME...]
+    haproxytool frontend [(-D DIR | -F SOCK) -f ] (-d | -t) [NAME...]
+    haproxytool frontend [(-D DIR | -F SOCK)] (-l | -M)
+    haproxytool frontend [(-D DIR | -F SOCK)] -m METRIC [NAME...]
 
 Arguments:
     DIR     Directory path
+    SOCK    Socket file
     VALUE   Value to set
     OPTION  Setting name
     METRIC  Name of a metric, use '-M' to get metric names
@@ -39,6 +40,7 @@ Options:
     -s, --status              show status
     -t, --shutdown            shutdown frontend
     -w, --write               change a frontend option
+    -F SOCK, --socket=SOCK    use specific socket file
     -D DIR, --socket-dir=DIR  directory with HAProxy socket files
                               [default: /var/lib/haproxy]
 
@@ -169,16 +171,28 @@ class FrontendCommand(object):
 def main():
     arguments = docopt(__doc__)
 
-    try:
-        hap = haproxy.HAProxy(socket_dir=arguments['--socket-dir'])
-    except (SocketApplicationError,
-            SocketConnectionError,
-            SocketPermissionError) as error:
-        print(error)
-        sys.exit(1)
-    except ValueError as error:
-        print(error)
-        sys.exit(1)
+    if (arguments['--socket']):
+        try:
+            hap = haproxy.HAProxy(socket_file=arguments['--socket'])
+        except (SocketApplicationError,
+                SocketConnectionError,
+                SocketPermissionError) as error:
+            print(error)
+            sys.exit(1)
+        except ValueError as error:
+            print(error)
+            sys.exit(1)
+    else:
+        try:
+            hap = haproxy.HAProxy(socket_dir=arguments['--socket-dir'])
+        except (SocketApplicationError,
+                SocketConnectionError,
+                SocketPermissionError) as error:
+            print(error)
+            sys.exit(1)
+        except ValueError as error:
+            print(error)
+            sys.exit(1)
 
     cmd = FrontendCommand(hap, arguments)
     method = get_arg_option(arguments)

--- a/haproxytool/haproxy.py
+++ b/haproxytool/haproxy.py
@@ -10,14 +10,15 @@
 """Manage haproxy
 
 Usage:
-    haproxytool haproxy [-D DIR ] (-a | -A | -C | -e | -i | -M | -o | -r | -u |
-                                   -U | -V | -R | -p)
-    haproxytool haproxy [-D DIR ] -m METRIC
-    haproxytool haproxy [-D DIR ] -w OPTION VALUE
-    haproxytool haproxy [-D DIR ] -c COMMAND
+    haproxytool haproxy [(-D DIR | -F SOCK)] (-a | -A | -C | -e | -i | -M |
+                                           -o | -r | -u | -U | -V | -R | -p)
+    haproxytool haproxy [(-D DIR | -F SOCK)] -m METRIC
+    haproxytool haproxy [(-D DIR | -F SOCK)] -w OPTION VALUE
+    haproxytool haproxy [(-D DIR | -F SOCK)] -c COMMAND
 
 Arguments:
     DIR     Directory path
+    SOCK    Socket file
     OPTION  Option name to set a VALUE
     VALUE   Value to set
     METRIC  Name of a metric, use '-M' to get metric names
@@ -41,6 +42,7 @@ Options:
     -V, --hap-version           show version of HAProxy
     -R, --release-date          show release date
     -w, --write                 set VALUE for an OPTION
+    -F SOCK, --socket=SOCK      use specific socket file
     -D DIR, --socket-dir=DIR    directory with HAProxy socket files
                                 [default: /var/lib/haproxy]
 
@@ -149,16 +151,28 @@ class HAProxyCommand(object):
 def main():
     arguments = docopt(__doc__)
 
-    try:
-        hap = haproxy.HAProxy(socket_dir=arguments['--socket-dir'])
-    except (SocketApplicationError,
-            SocketConnectionError,
-            SocketPermissionError) as error:
-        print(error)
-        sys.exit(1)
-    except ValueError as error:
-        print(error)
-        sys.exit(1)
+    if (arguments['--socket']):
+        try:
+            hap = haproxy.HAProxy(socket=arguments['--socket'])
+        except (SocketApplicationError,
+                SocketConnectionError,
+                SocketPermissionError) as error:
+            print(error)
+            sys.exit(1)
+        except ValueError as error:
+            print(error)
+            sys.exit(1)
+    else:
+        try:
+            hap = haproxy.HAProxy(socket_dir=arguments['--socket-dir'])
+        except (SocketApplicationError,
+                SocketConnectionError,
+                SocketPermissionError) as error:
+            print(error)
+            sys.exit(1)
+        except ValueError as error:
+            print(error)
+            sys.exit(1)
 
     cmd = HAProxyCommand(hap, arguments)
     method = get_arg_option(arguments)

--- a/haproxytool/map.py
+++ b/haproxytool/map.py
@@ -9,15 +9,16 @@
 """Manage MAPs
 
 Usage:
-    haproxytool map [-D DIR | -h] -l
-    haproxytool map [-D DIR | -h] (-s | -c ) MAPID
-    haproxytool map [-D DIR | -h] -g MAPID KEY
-    haproxytool map [-D DIR | -h] (-S | -A) MAPID KEY VALUE
-    haproxytool map [-D DIR | -h] -d MAPID KEY
+    haproxytool map [(-D DIR | -F SOCK) | -h] -l
+    haproxytool map [(-D DIR | -F SOCK) | -h] (-s | -c ) MAPID
+    haproxytool map [(-D DIR | -F SOCK) | -h] -g MAPID KEY
+    haproxytool map [(-D DIR | -F SOCK) | -h] (-S | -A) MAPID KEY VALUE
+    haproxytool map [(-D DIR | -F SOCK) | -h] -d MAPID KEY
 
 
 Arguments:
     DIR     Directory path
+    SOCK    Socket file
     MAPID   ID of the map or file returned by show map
     KEY     ID of key
     VALUE   Value to set
@@ -32,6 +33,7 @@ Options:
     -S, --set                 set a new value for a key in a map
     -d, --delete              delete all the map entries from the map <MAPID>
                               corresponding to the key <KEY>
+    -F SOCK, --socket=SOCK    use specific socket file
     -D DIR, --socket-dir=DIR  directory with HAProxy socket files
                               [default: /var/lib/haproxy]
 
@@ -121,16 +123,28 @@ class MapCommand(object):
 
 def main():
     arguments = docopt(__doc__)
-    try:
-        hap = haproxy.HAProxy(socket_dir=arguments['--socket-dir'])
-    except (SocketApplicationError,
-            SocketConnectionError,
-            SocketPermissionError) as error:
-        print(error)
-        sys.exit(1)
-    except ValueError as error:
-        print(error)
-        sys.exit(1)
+    if (arguments['--socket']):
+        try:
+            hap = haproxy.HAProxy(socket_file=arguments['--socket'])
+        except (SocketApplicationError,
+                SocketConnectionError,
+                SocketPermissionError) as error:
+            print(error)
+            sys.exit(1)
+        except ValueError as error:
+            print(error)
+            sys.exit(1)
+    else:
+        try:
+            hap = haproxy.HAProxy(socket_dir=arguments['--socket-dir'])
+        except (SocketApplicationError,
+                SocketConnectionError,
+                SocketPermissionError) as error:
+            print(error)
+            sys.exit(1)
+        except ValueError as error:
+            print(error)
+            sys.exit(1)
 
     cmd = MapCommand(hap, arguments)
     method = get_arg_option(arguments)

--- a/haproxytool/server.py
+++ b/haproxytool/server.py
@@ -10,16 +10,17 @@
 """Manage servers
 
 Usage:
-    haproxytool server [-D DIR ] (-r | -s | -e | -R | -p | -W | -i | -c | -C |
-                                  -S) [--backend=<name>...] [NAME...]
-    haproxytool server [-D DIR ] -w VALUE [--backend=<name>...] [NAME...]
-    haproxytool server [-D DIR -f ] (-d | -t | -n) [--backend=<name>...] [NAME...]
-    haproxytool server [-D DIR ] (-l | -M)
-    haproxytool server [-D DIR ] -m METRIC [--backend=<name>...] [NAME...]
+    haproxytool server [(-D DIR | -F SOCK)] (-r | -s | -e | -R | -p | -W | 
+                    -i | -c | -C | -S) [--backend=<name>...] [NAME...]
+    haproxytool server [(-D DIR | -F SOCK)] -w VALUE [--backend=<name>...] [NAME...]
+    haproxytool server [(-D DIR | -F SOCK) -f ] (-d | -t | -n) [--backend=<name>...] [NAME...]
+    haproxytool server [(-D DIR | -F SOCK)] (-l | -M)
+    haproxytool server [(-D DIR | -F SOCK)] -m METRIC [--backend=<name>...] [NAME...]
 
 
 Arguments:
     DIR     Directory path
+    SOCK    Socket file
     VALUE   Value to set
     METRIC  Name of a metric, use '-M' to get metric names
 
@@ -43,6 +44,7 @@ Options:
     -t, --maintenance         set server in maintenance mode
     -w, --weight              change weight for server
     -W, --get-weight          show weight of server
+    -F SOCK, --socket=SOCK    use specific socket file
     -D DIR, --socket-dir=DIR  directory with HAProxy socket files
                               [default: /var/lib/haproxy]
 
@@ -247,16 +249,28 @@ class ServerCommand(object):
 
 def main():
     arguments = docopt(__doc__)
-    try:
-        hap = haproxy.HAProxy(socket_dir=arguments['--socket-dir'])
-    except (SocketApplicationError,
-            SocketConnectionError,
-            SocketPermissionError) as error:
-        print(error)
-        sys.exit(1)
-    except ValueError as error:
-        print(error)
-        sys.exit(1)
+    if (arguments['--socket']):
+        try:
+            hap = haproxy.HAProxy(socket_file=arguments['--socket'])
+        except (SocketApplicationError,
+                SocketConnectionError,
+                SocketPermissionError) as error:
+            print(error)
+            sys.exit(1)
+        except ValueError as error:
+            print(error)
+            sys.exit(1)
+    else:
+        try:
+            hap = haproxy.HAProxy(socket_dir=arguments['--socket-dir'])
+        except (SocketApplicationError,
+                SocketConnectionError,
+                SocketPermissionError) as error:
+            print(error)
+            sys.exit(1)
+        except ValueError as error:
+            print(error)
+            sys.exit(1)
 
     cmd = ServerCommand(hap, arguments)
     method = get_arg_option(arguments)


### PR DESCRIPTION
```
My use case is that the socket_dir method scans a directory and errors out if it can't read any of the sockets, whether they are haproxy related sockets or not.
```
